### PR TITLE
Splitting default class instances into independent ones after calling run_config.get_renewed_self_instance()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "branch_storm"
-version = "1.0.5"
+version = "1.0.7"
 
 description = "branch_storm package"
 authors = ["Dmitrii Zhitin <3271707@gmail.com>"]

--- a/src/branch_storm/default/rw_classes.py
+++ b/src/branch_storm/default/rw_classes.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from dataclasses import dataclass, Field, field
+from dataclasses import dataclass
 from typing import Optional, Tuple, Any, Dict, List, Type, Callable, Union
 
 from ..constants import INITIAL_RUN, DEFAULT_BRANCH_OPTIONS, INITIAL
@@ -7,16 +7,27 @@ from ..utils.options_utils import OptionsChecker
 
 
 _ALLOWED_SCALARS = (str, int, float, complex, range,
-                    bool, bytes, bytearray, memoryview)
+                    bool, bytes, memoryview)
 
 def _is_dunder(name: str) -> bool:
     return name.startswith("__") and name.endswith("__")
 
 
+def _is_immutable(value: Any) -> bool:
+    """Recursive immutability check for allowed atoms + (tuple|frozenset) nesting."""
+    if isinstance(value, _ALLOWED_SCALARS):
+        return True
+    if isinstance(value, tuple):
+        return all(_is_immutable(v) for v in value)
+    if isinstance(value, frozenset):
+        return all(_is_immutable(v) for v in value)
+    return False
+
+
 @dataclass
 class Values:
     """One time write then read only built-in immutable pos_args or pos_args structures:
-    str, int, float, complex, tuple, range, frozenset, bool, bytes, bytearray, memoryview
+    str, int, float, complex, tuple, range, frozenset, bool, bytes, memoryview
 
     (tuple and frozenset can contain nested structures of each other's types)
     Writing other types will throw an exception.
@@ -25,49 +36,45 @@ class Values:
     """
     _op_stack_name: str = ""
 
-    def __setattr__(self, key, value):
-        if key in self.__dict__ and key != "_op_stack_name":
-            start_mess = f"Operation: {self._op_stack_name}. " if \
-            self._op_stack_name else ""
-            raise ValueError(
-                f"{start_mess}The value cannot be overwritten. "
-                f"The class is intended for single-write and read use.")
-        if isinstance(value, Field):
-            dcl_field = value
-            value = dcl_field.default
-            self.__dataclass_fields__[key] = dcl_field
-        else:
-            self.__check_data_structure(value)
-            self.__dataclass_fields__[key] = field(default=value)
-        self.__dict__[key] = value
+    def _set_op_stack(self, name: str) -> None:
+        """Allow external code to set operation stack name for error context."""
+        object.__setattr__(self, "_op_stack_name", name or "")
 
-    def __check_data_structure(self, value) -> None:
-        if isinstance(value, (frozenset, tuple)):
-            for pos in value:
-                self.__check_data_structure(pos)
-            return None
-        if isinstance(value, _ALLOWED_SCALARS):
-            return None
-        start_mess = f"Operation: {self._op_stack_name}. " if \
-            self._op_stack_name else ""
-        raise TypeError(
-            f"{start_mess}The pos_args or pos_args "
-            f"structure being written has types other than: "
-            f"str, int, float, complex, tuple, range, frozenset, "
-            f"bool, bytes, bytearray, memoryview.")
+    def _get_new_instance(self) -> "Values":
+        """
+        Return a new Values instance. Reuses references
+        to already stored fields with the same names.
+        """
+        new = Values(self._op_stack_name)
+        for k, v in self.__dict__.items():
+            if k.startswith("_"):
+                continue
+            object.__setattr__(new, k, v)
+        return new
 
-    def __getattribute__(self, item):
-        if item in ("_op_stack_name",
-                    "_Values__check_data_structure") or _is_dunder(item):
-            return super().__getattribute__(item)
+    def __setattr__(self, key: str, value: Any) -> None:
+        if key == "_op_stack_name":
+            object.__setattr__(self, key, value)
+            return
 
-        dct = super().__getattribute__("__dict__")
-        if item not in dct:
-            op = dct.get("_op_stack_name", "")
-            start = f"Operation: {op}. " if op else ""
-            raise AttributeError(f"{start}No such attribute in Values")
+        if key in self.__dict__:
+            start = f"Operation: {self._op_stack_name}. " if self._op_stack_name else ""
+            raise ValueError(f"{start}The value cannot be overwritten. "
+                             f"The class is intended for single-write and read use.")
 
-        return super().__getattribute__(item)
+        if not _is_immutable(value):
+            start = f"Operation: {self._op_stack_name}. " if self._op_stack_name else ""
+            raise TypeError(f"{start}The pos_args or pos_args structure being written has types other than: "
+                            f"str, int, float, complex, tuple, range, frozenset, bool, bytes, memoryview.")
+
+        object.__setattr__(self, key, value)
+
+    def __getattr__(self, item: str) -> Any:
+        if _is_dunder(item):
+            raise AttributeError
+        op = getattr(self, "_op_stack_name", "")
+        start = f"Operation: {op}. " if op else ""
+        raise AttributeError(f"{start}No such attribute in Values")
 
 
 @dataclass
@@ -75,26 +82,26 @@ class Variables:
     """Write, rewrite and read any pos_args structures."""
     _op_stack_name: str = ""
 
-    def __setattr__(self, key, value):
-        if isinstance(value, Field):
-            dcl_field = value
-            value = dcl_field.default
-            self.__dataclass_fields__[key] = dcl_field
-        else:
-            self.__dataclass_fields__[key] = field(default=value)
-        self.__dict__[key] = value
+    def _set_op_stack(self, name: str) -> None:
+        object.__setattr__(self, "_op_stack_name", name or "")
 
-    def __getattribute__(self, item):
-        if item == "_op_stack_name" or _is_dunder(item):
-            return super().__getattribute__(item)
+    def _get_new_instance(self) -> "Variables":
+        new = Variables(self._op_stack_name)
+        for k, v in self.__dict__.items():
+            if k == "_op_stack_name":
+                continue
+            object.__setattr__(new, k, v)
+        return new
 
-        dct = super().__getattribute__("__dict__")
-        if item not in dct:
-            op = dct.get("_op_stack_name", "")
-            start = f"Operation: {op}. " if op else ""
-            raise AttributeError(f"{start}No such attribute in Variables")
+    def __setattr__(self, key: str, value: Any) -> None:
+        object.__setattr__(self, key, value)
 
-        return super().__getattribute__(item)
+    def __getattr__(self, item: str) -> Any:
+        if _is_dunder(item):
+            raise AttributeError
+        op = getattr(self, "_op_stack_name", "")
+        start = f"Operation: {op}. " if op else ""
+        raise AttributeError(f"{start}No such attribute in Variables")
 
 
 class RwInstUpdater:
@@ -190,7 +197,7 @@ class RwInstUpdater:
             stack: str, updated_cl: Dict[str, Any]) -> Dict[str, Any]:
         for alias, inst in updated_cl.items():
             if isinstance(inst, (Values, Variables)):
-                inst._op_stack_name = stack
+                inst._set_op_stack(stack)
                 updated_cl[alias] = inst
         return updated_cl
 
@@ -438,9 +445,17 @@ class RunConfigurations:
         return {**base_map, "run_conf": self}
 
     def get_renewed_self_instance(self) -> 'RunConfigurations':
-        new_rw_inst = RunConfigurations._renew_def_rw_inst(
-            self.operation_stack, self.get_rw_inst())
-        return new_rw_inst["run_conf"]
+        """Return a new instance RunConfigurations with:
+           - copied field values (shallow),
+           - the SAME opt_stack items except the LAST one,
+           - a NEW last BranchOptions wired to a NEW rw_inst map,
+             where Values/Variables are renewed via _get_new_instance(),
+             and run_conf points to this new RunConfigurations.
+        """
+        stack = self.operation_stack or self.get_branch_stack()
+        current_map = self.get_rw_inst()
+        renewed_map = RunConfigurations._renew_def_rw_inst(stack, current_map)
+        return renewed_map["run_conf"]
 
     def pop_stack(self):
         new_delay_return = self._pop_delayed_return()
@@ -458,7 +473,7 @@ class RunConfigurations:
         if last_delay_return is not None:
             prev_delayed_return = self.opt_stack[-2].delayed_return
             if prev_delayed_return is not None:
-                return *prev_delayed_return, *last_delay_return
+                return (*prev_delayed_return, *last_delay_return)
 
     def _pop_rw_inst(self) -> Tuple:
         penult_map = dict(self.opt_stack[-2].rw_inst)
@@ -505,35 +520,68 @@ class RunConfigurations:
             stack: str,
             old_rw_inst: Dict[str, Any],
             rw_class: Type) -> Dict[str, Any]:
-        for alias, rw_inst in old_rw_inst.items():
-            if isinstance(rw_inst, rw_class):
-                new_inst = rw_class()
-                new_inst._op_stack_name = stack
-                for field, value in rw_inst.__dict__.items():
-                    setattr(new_inst, field, value)
-                return {alias: new_inst}
+        """Renew ALL default instances of rw_class found in old_rw_inst."""
+        renewed: Dict[str, Any] = {}
+        for alias, inst in old_rw_inst.items():
+            if isinstance(inst, rw_class):
+                new_inst = inst._get_new_instance()
+                new_inst._set_op_stack(stack)
+                renewed[alias] = new_inst
+        return renewed
 
     @staticmethod
     def _renew_run_conf(old_rw_inst: Dict[str, Any]) -> Dict[str, Any]:
-        for alias, rw_inst in old_rw_inst.items():
-            if isinstance(rw_inst, RunConfigurations):
-                new_inst = RunConfigurations()
-                for field, value in rw_inst.__dict__.items():
-                    setattr(new_inst, field, value)
-                new_opt_inst = new_inst.br_opt.get_new_instance()
-                new_inst.br_opt = new_opt_inst
-                return {alias: new_inst}
+        for alias, inst in old_rw_inst.items():
+            if isinstance(inst, RunConfigurations):
+                old_rc: RunConfigurations = inst
+                new_rc = RunConfigurations()
+                for field, value in old_rc.__dict__.items():
+                    setattr(new_rc, field, value)
+
+                if old_rc.opt_stack and len(old_rc.opt_stack) > 0:
+                    old_last_opt = old_rc.opt_stack[-1]
+                else:
+                    old_last_opt = old_rc.br_opt
+
+                new_last_opt = old_last_opt.get_new_instance()
+
+                prev = old_rc.opt_stack[:-1] if (
+                        old_rc.opt_stack and len(
+                    old_rc.opt_stack) > 0) else tuple()
+                new_rc.opt_stack = (*prev, new_last_opt)
+                new_rc.br_opt = new_last_opt
+
+                return {alias: new_rc}
+        return {}
 
     @staticmethod
-    def _renew_def_rw_inst(stack: str, rw_inst: Dict[str, Any]) -> Dict[str, Any]:
-        if rw_inst:
-            return {
-                **rw_inst,
-                **RunConfigurations._renew_def_instance(stack, rw_inst, Values),
-                **RunConfigurations._renew_def_instance(stack, rw_inst, Variables),
-                **RunConfigurations._renew_run_conf(rw_inst),
-            }
-        return rw_inst
+    def _renew_def_rw_inst(
+            stack: str, rw_inst: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a NEW rw_inst map where:
+           - Values/Variables are renewed via _get_new_instance()
+           - run_conf is replaced with a NEW RunConfigurations (with new last BranchOptions)
+           - new_rc.br_opt.rw_inst points to the returned map (self-consistent)
+        """
+        if not rw_inst:
+            return rw_inst
+
+        base = dict(rw_inst)
+
+        renewed = {**base}
+        renewed.update(RunConfigurations._renew_def_instance(
+            stack, base, Values))
+        renewed.update(RunConfigurations._renew_def_instance(
+            stack, base, Variables))
+
+        run_conf_map = RunConfigurations._renew_run_conf(base)
+        if run_conf_map:
+            renewed.update(run_conf_map)
+
+            new_rc: RunConfigurations = run_conf_map.get("run_conf")
+            renewed["run_conf"] = new_rc
+            new_rc.br_opt.rw_inst = renewed
+
+        return renewed
 
     def __post_init__(self):
         br_opt = BranchOptions()

--- a/src/branch_storm/initialization_core.py
+++ b/src/branch_storm/initialization_core.py
@@ -1,4 +1,3 @@
-import uuid
 from dataclasses import dataclass, field
 from inspect import Parameter
 from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Type, Union

--- a/tests/launch/test_assign.py
+++ b/tests/launch/test_assign.py
@@ -68,8 +68,8 @@ def test_renew_rw_inst():
             'last_op_stack': 'INITIAL RUN',
             'operation_stack': 'Initial -> OP',
             'stack_divider': ' -> '},
-        'val': {'_op_stack_name': '', 'val_field1': 1, 'val_field2': 2},
-        'var': {'_op_stack_name': '', 'var_field1': 1},
+        'val': {'_op_stack_name': 'st -> ack', 'val_field1': 1, 'val_field2': 2},
+        'var': {'_op_stack_name': 'st -> ack', 'var_field1': 1},
         'st': {'t_class': ThirdStorage(third_val=3)}}
 
     assert base_id["val"] != actual_result_id["val"]

--- a/tests/launch/test_capture.py
+++ b/tests/launch/test_capture.py
@@ -7,7 +7,7 @@ import pytest
 
 import tests
 from src.branch_storm import RunConfigurations, parallelize_without_result, \
-    Values, STOP_CONSTANT
+    Values
 from src.branch_storm.operation import Operation as op, CallObject as obj
 from src.branch_storm.branch import Branch as br
 from src.branch_storm.type_containers import MandatoryArgTypeContainer as m, OptionalArgTypeContainer as opt

--- a/tests/launch/test_finish_execution.py
+++ b/tests/launch/test_finish_execution.py
@@ -1,10 +1,13 @@
 import re
+from dataclasses import dataclass
+from functools import wraps
 from typing import Any, Union
 
 import pytest
 
+from src.branch_storm import typed_alias, RunConfigurations
 from src.branch_storm.constants import STOP_CONSTANT
-from src.branch_storm.launch_operations.errors import EmptyDataError, ConditionNotMetError
+from src.branch_storm.launch_operations.errors import ConditionNotMetError
 from src.branch_storm.operation import Operation as op, CallObject as obj
 from src.branch_storm.branch import Branch as br
 from src.branch_storm.type_containers import MandatoryArgTypeContainer as m
@@ -336,3 +339,42 @@ def test_hide_log_inf():
     ].hide_log_inf(True).run()
 
     assert actual_result == 11
+
+
+def test_stop_execution_with_decorator_and_branch_break():
+    @dataclass
+    class JA:
+        err_mess: str = "error"
+
+    def catch_exception(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except Exception as exc:
+                return kwargs["job_args"].err_mess
+        return wrapper
+
+    @catch_exception
+    def wrapped_func(err: bool, *, job_args: JA):
+        if err is True:
+            raise TypeError
+        else:
+            return STOP_CONSTANT
+
+    ja = typed_alias("ja", JA)
+    run_conf = typed_alias("run_conf", RunConfigurations)
+
+    def calc_nested_br(run_conf: RunConfigurations):
+        res = br("nested")[
+            obj(wrapped_func)(False, job_args=m(ja)[JA])
+        ].rw_inst({"run_conf": run_conf}).run()
+        res: RunConfigurations = res[2]
+        res = res.get_rw_inst()["ja"].err_mess
+        return res
+
+    actual_result = br("decorator_test")[
+        obj(calc_nested_br)(m(run_conf)),
+    ].rw_inst({"ja": JA()}).run()
+
+    assert actual_result == "error"

--- a/tests/launch/test_parallel_run.py
+++ b/tests/launch/test_parallel_run.py
@@ -3,7 +3,9 @@ from typing import Tuple, Optional
 
 import pytest
 
-from src.branch_storm.default.parallelism import create_init_data_sequence, parallelize_without_result
+from src.branch_storm import STOP_CONSTANT
+from src.branch_storm.default.parallelism import create_init_data_sequence, \
+    parallelize_without_result, parallelize_with_result_return
 from src.branch_storm.operation import Operation as op, CallObject as obj
 from src.branch_storm.branch import Branch as br, Branch
 from src.branch_storm.type_containers import MandatoryArgTypeContainer as m, OptionalArgTypeContainer as opt
@@ -57,11 +59,14 @@ def transform(arg): return arg + 1
 def get_three_return_sum(arg1: int, arg2: int, arg3: int
                          ) -> int: return sum([arg1, arg2, arg3])
 
-def write(arg: int, table_name: str) -> None:
+def write(arg: int, table_name: str) -> str:
     global actual_result, table_name_result
     actual_result += [arg]
     table_name_result += [table_name]
-    return None
+
+    if table_name == 'dim_sale':
+        return STOP_CONSTANT
+    return table_name
 
 
 @dataclass
@@ -91,7 +96,8 @@ def dim_branches(table_name: str) -> Branch:
             obj(transform)(m("val.int_storage")[int])
         ].distribute_input_data,
         obj(get_three_return_sum)(m[int], m[int], m[int]),
-        obj(write)(m[int], table_name=m("tns.name")[str])
+        op(obj(write)(m[int], table_name=m("tns.name")[str])
+           ).assign("val.table_name")
     ].rw_inst({"tns": TableNameStorage()})
 
 
@@ -134,17 +140,20 @@ def test_process_few_branches_parallel_with_initial_data(get_table_branches):
         "api_to_json": [...],
         "json_to_parquet": [...],
         "trusted_to_enriched": br("trusted_to_enriched")[
-             obj(parallelize_without_result)(
+             obj(parallelize_with_result_return)(
                  m("run_conf"), table_branches, threads=m("ja.threads"),
                  idata_for_each=(initial_data,))
         ].rw_inst({"ja": ja})
     }       
 
     exec_result = objects_for_processing.get(ja.job_name).run()
+    val_result = [res[2].get_rw_inst()['val'].table_name for res in
+                  exec_result]
 
     global actual_result, table_name_result
     assert sorted(actual_result) == [12, 15, 18]
     assert sorted(table_name_result) == ['dim_kale', 'dim_pale', 'dim_sale']
-    assert exec_result is None
+    assert sorted(val_result) == ['dim_kale', 'dim_pale', STOP_CONSTANT]
+
     actual_result = []
     table_name_result = []

--- a/tests/launch/test_run_configurations.py
+++ b/tests/launch/test_run_configurations.py
@@ -1,0 +1,142 @@
+from src.branch_storm.default.rw_classes import (
+    RunConfigurations, BranchOptions, Values, Variables)
+
+def find_aliases_by_type(m: dict, cls):
+    return [k for k, v in m.items() if isinstance(v, cls)]
+
+def pick_alias(m: dict, cls, prefer = None):
+    aliases = find_aliases_by_type(m, cls)
+    if not aliases:
+        raise AssertionError(f"Alias for {cls.__name__} not found in map: {m.keys()}")
+    if prefer and prefer in aliases:
+        return prefer
+    return aliases[0]
+
+def make_rc_with_custom_stack():
+    rc = RunConfigurations()
+
+    bo_last = BranchOptions(
+        br_name="B1",
+        assign=("x",),
+        force_call=True,
+        rw_inst=({"cfg": {"x": 1}, "val2": Values()},))
+    rc.add_br_opt_to_stack(bo_last)
+
+    rc.set_operation_stack("DoStuff")
+
+    m = rc.br_opt.rw_inst
+    val_aliases = find_aliases_by_type(m, Values)
+    var_alias = pick_alias(m, Variables, prefer="var")
+
+    for i, a in enumerate(val_aliases, start=1):
+        getattr(m, "keys", lambda: None)
+        m[a].__setattr__(f"a{i}", (i, i+1))
+
+    m[var_alias].num = 42
+    sentinel = object()
+    m[var_alias].obj = sentinel
+
+    return rc
+
+
+def test_returns_new_rc_and_keeps_stack_shape():
+    rc1 = make_rc_with_custom_stack()
+    rc2 = rc1.get_renewed_self_instance()
+
+    assert rc1 is not rc2
+    assert len(rc1.opt_stack) == len(rc2.opt_stack) == 2
+
+    assert rc2.opt_stack[0] is rc1.opt_stack[0]
+
+    assert rc2.opt_stack[-1] is not rc1.opt_stack[-1]
+    assert rc2.br_opt is rc2.opt_stack[-1]
+
+    assert rc2.br_opt.rw_inst is not rc1.br_opt.rw_inst
+    assert rc2.br_opt.rw_inst["run_conf"] is rc2
+
+
+def test_default_instances_renewed_and_data_carried():
+    rc1 = make_rc_with_custom_stack()
+    m1 = rc1.br_opt.rw_inst
+
+    val_aliases_1 = find_aliases_by_type(m1, Values)
+    var_alias_1 = pick_alias(m1, Variables, prefer="var")
+
+    rc2 = rc1.get_renewed_self_instance()
+    m2 = rc2.br_opt.rw_inst
+
+    val_aliases_2 = find_aliases_by_type(m2, Values)
+    assert len(val_aliases_2) >= 1
+    var_alias_2 = pick_alias(m2, Variables, prefer=var_alias_1)
+
+    for i, a1 in enumerate(val_aliases_1, start=1):
+        assert a1 in m2, f"Missing Values alias {a1} in renewed map"
+        v1, v2 = m1[a1], m2[a1]
+        assert isinstance(v2, Values)
+        assert v2 is not v1
+        assert getattr(v2, f"a{i}") == (i, i + 1)
+
+    v1, v2 = m1[var_alias_1], m2[var_alias_2]
+    assert isinstance(v2, Variables)
+    assert v2 is not v1
+    assert v2.num == 42
+    assert v2.obj is v1.obj
+
+
+def test_op_stack_name_is_set_for_renewed_defaults():
+    rc1 = make_rc_with_custom_stack()
+    expected_stack = rc1.operation_stack
+    rc2 = rc1.get_renewed_self_instance()
+    m2 = rc2.br_opt.rw_inst
+
+    for a in find_aliases_by_type(m2, Values):
+        assert m2[a]._op_stack_name == expected_stack
+    for a in find_aliases_by_type(m2, Variables):
+        assert m2[a].__dict__.get("_op_stack_name") == expected_stack
+
+
+def test_branch_options_fields_copied_in_last_only():
+    rc1 = make_rc_with_custom_stack()
+
+    rc1.br_opt.raise_err_cond = lambda x: False
+    rc1.br_opt.distribute_input_data = True
+
+    rc2 = rc1.get_renewed_self_instance()
+
+    assert rc2.opt_stack[0] is rc1.opt_stack[0]
+
+    old_last = rc1.opt_stack[-1]
+    new_last = rc2.opt_stack[-1]
+
+    assert new_last is not old_last
+    assert new_last.br_name == old_last.br_name
+    assert new_last.assign == old_last.assign
+    assert new_last.force_call == old_last.force_call
+    assert bool(new_last.distribute_input_data) == bool(
+        old_last.distribute_input_data)
+    assert new_last.raise_err_cond is old_last.raise_err_cond
+
+
+def test_self_consistency_links():
+    rc1 = make_rc_with_custom_stack()
+
+    m1_before = rc1.br_opt.rw_inst
+    run_conf1_before = m1_before.get("run_conf")
+
+    rc2 = rc1.get_renewed_self_instance()
+
+    m2 = rc2.br_opt.rw_inst
+    assert m2["run_conf"] is rc2
+    assert rc2.br_opt.rw_inst is m2
+
+    assert rc1.br_opt.rw_inst is m1_before
+    assert rc1.br_opt.rw_inst.get("run_conf") is run_conf1_before
+
+
+def test_cfg_alias_preserved_by_reference():
+    rc1 = make_rc_with_custom_stack()
+    cfg_before = rc1.br_opt.rw_inst["cfg"]
+    rc2 = rc1.get_renewed_self_instance()
+    cfg_after = rc2.br_opt.rw_inst["cfg"]
+
+    assert cfg_after is cfg_before


### PR DESCRIPTION
Splitting default class instances into independent ones after calling run_config.get_renewed_self_instance()